### PR TITLE
Update regression sequence to pass extra params

### DIFF
--- a/jenkins/jobs/Create Resources/config.xml
+++ b/jenkins/jobs/Create Resources/config.xml
@@ -27,12 +27,18 @@
           </choices>
         </hudson.model.ChoiceParameterDefinition>
         <hudson.model.TextParameterDefinition>
-          <name>config</name>
+          <name>topology</name>
           <description>Text from the config file ie. build_config_file_setup.lst</description>
           <defaultValue></defaultValue>
         </hudson.model.TextParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.7.2">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
@@ -51,7 +57,7 @@ git checkout $branch
 cd ..
 mkdir credentials
 cat &gt; credentials/config &lt;&lt;EOF
-$config
+$topology
 EOF
 
 mkdir virtualenv/

--- a/jenkins/jobs/Create Users/config.xml
+++ b/jenkins/jobs/Create Users/config.xml
@@ -27,12 +27,18 @@
           </choices>
         </hudson.model.ChoiceParameterDefinition>
         <hudson.model.TextParameterDefinition>
-          <name>config</name>
+          <name>topology</name>
           <description>Text from the config file ie. build_config_file_setup.lst</description>
           <defaultValue></defaultValue>
         </hudson.model.TextParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.7.2">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
@@ -51,7 +57,7 @@ git checkout $branch
 cd ..
 mkdir credentials
 cat &gt; credentials/config &lt;&lt;EOF
-$config
+$topology
 EOF
 
 mkdir virtualenv/

--- a/jenkins/jobs/Full Regression Sequence/config.xml
+++ b/jenkins/jobs/Full Regression Sequence/config.xml
@@ -6,15 +6,27 @@
   <properties>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>repo_url</name>
+          <description>Eutester repository to clone tests from</description>
+          <defaultValue>git://github.com/eucalyptus/eutester.git</defaultValue>
+        </hudson.model.StringParameterDefinition>
         <hudson.model.TextParameterDefinition>
           <name>eucarc</name>
           <description>Eucarc file containing credentials of eucalyptus/admin</description>
           <defaultValue></defaultValue>
         </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>topology</name>
+          <description>Machine configuration topology.</description>
+          <defaultValue>&lt;ipaddress&gt; CENTOS 6.4 64 REPO [CLC WS CC00 SC00]
+&lt;ipaddress&gt; CENTOS 6.4 64 REPO [NC00]
+</defaultValue>
+        </hudson.model.TextParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>repo_url</name>
-          <description>Eutester repository to clone tests from</description>
-          <defaultValue>git://github.com/eucalyptus/eutester.git</defaultValue>
+          <name>imgurl</name>
+          <description>Image URL for BFEBS image.</description>
+          <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>branch</name>
@@ -28,6 +40,12 @@
         </hudson.model.ChoiceParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.7.2">
+      <maxConcurrentPerNode>0</maxConcurrentPerNode>
+      <maxConcurrentTotal>0</maxConcurrentTotal>
+      <throttleEnabled>false</throttleEnabled>
+      <throttleOption>project</throttleOption>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>


### PR DESCRIPTION
Some tests in the regression sequence require providing
cloud topology and an image url for bfebs. Include these
params and make jobs consistent with param naming so they
can use these.
